### PR TITLE
release/public-v1: add compiler flags for gfortran-10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,11 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
   set(CMAKE_Fortran_FLAGS_DEBUG "-ggdb -Wall")
 endif()
 
+# For gfortran-10+ backward compatibility
+if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_Fortran_COMPILER_VERSION} VERSION_GREATER 9.9)
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -w -fallow-argument-mismatch")
+endif()
+
 find_package(MPI REQUIRED COMPONENTS Fortran)
 
 set(fortran_src


### PR DESCRIPTION
Something must have gone wrong when merging https://github.com/NOAA-EMC/NCEPLIBS-nemsio/pull/24 or previously; updates from develop have sneaked into release/public-v1. This PR restores the original release/public-v1 branch with the gfortran-10 compiler flags added on top. Will merge right away. Sorrry for the confusion.