### PR TITLE
Add IntelLLVM support & Spack-based CI tests

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -1,0 +1,86 @@
+# This is a GitHub CI workflow for the NCEPLIBS-nemsio project.
+#
+# This workflow runs the intel compiler.
+#
+# Ed Hartnett 1/12/23
+name: Intel
+on:
+  push:
+    branches:
+    - develop
+  pull_request:
+    branches:
+    - develop
+
+# Use custom shell with -l so .bash_profile is sourced which loads intel/oneapi/setvars.sh
+# without having to do it in manually every step
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
+jobs:
+  Intel:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compilers: ["oneapi", "classic"]
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+      # See https://software.intel.com/content/www/us/en/develop/articles/oneapi-repo-instructions.html
+    - name: install-intel
+      run: |
+        cd /tmp
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
+        sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-openmp intel-oneapi-mpi intel-oneapi-mpi-devel intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-compiler-fortran
+        echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
+        if [ ${{ matrix.compilers }} == "oneapi" ]; then
+          echo "export CC=mpiicx FC=mpiifx" >> ~/.bash_profile
+        elif [ ${{ matrix.compilers }} == "intel" ]; then
+          echo "export CC=mpiicc FC=mpiifort" >> ~/.bash_profile
+        fi
+
+    - name: checkout-bacio
+      uses: actions/checkout@v2
+      with:
+        repository: NOAA-EMC/NCEPLIBS-bacio
+        path: bacio
+        ref: develop
+
+    - name: build-bacio
+      run: |
+        cd bacio
+        mkdir build
+        cd build
+        cmake .. -DCMAKE_INSTALL_PREFIX=~/bacio
+        make -j2
+        make install
+
+    - name: checkout-w3emc
+      uses: actions/checkout@v2
+      with:
+        repository: NOAA-EMC/NCEPLIBS-w3emc
+        path: w3emc
+        ref: develop
+
+    - name: build-w3emc
+      run: |
+        cd w3emc
+        mkdir build
+        cd build
+        cmake .. -DCMAKE_INSTALL_PREFIX=~/w3emc -DCMAKE_PREFIX_PATH="~/" -DBUILD_WITH_BUFR=OFF
+        make -j2
+        make install
+
+    - name: build and test
+      run: |
+        mkdir build && cd build
+        cmake -DCMAKE_PREFIX_PATH='~/bacio;~/w3emc' ..
+        make -j2 VERBOSE=1
+        ctest --verbose --output-on-failure --rerun-failed

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -1,0 +1,94 @@
+# This is a CI workflow for the NCEPLIBS-nemsio project.
+#
+# This workflow builds nemsio with Spack, including installing with the "--test
+# root" option to run the Ctest suite. It also has a one-off job that validates
+# the recipe by ensuring that every CMake option that should be set in the
+# Spack recipe is so set.
+#
+# Alex Richert, Sep 2023
+name: Spack
+on:
+  push:
+    branches:
+    - develop
+  pull_request:
+    branches:
+    - develop
+
+jobs:
+  Spack:
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+        variants: ["+mpi", "~mpi"]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    
+    - name: checkout-nemsio
+      uses: actions/checkout@v4
+      with: 
+        path: nemsio
+
+    - name: cache-spack
+      id: cache-spack
+      uses: actions/cache@v3
+      with:
+        path: ~/spack-build-cache
+        key: spack-build-cache-${{ matrix.os }}-${{ matrix.variants }}-1
+
+    - name: spack-build-and-test
+      run: |
+        if [[ "${{ matrix.variants }}" =~ "+mpi" ]]; then
+          sudo apt install openmpi-bin libopenmpi-dev
+        fi
+        cd
+        git clone -c feature.manyFiles=true https://github.com/jcsda/spack
+        . spack/share/spack/setup-env.sh
+        spack env create nemsio-env
+        spack env activate nemsio-env
+        cp $GITHUB_WORKSPACE/nemsio/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/nemsio/package.py
+        spack develop --no-clone --path $GITHUB_WORKSPACE/nemsio nemsio@develop
+        spack config add "packages:all:providers:mpi:[openmpi]"
+        spack add nemsio@develop%gcc@11 ${{ matrix.variants }} ^bufr~python
+        spack external find cmake gmake openmpi
+        spack config add "packages:openmpi:buildable:false"
+        for mirror in $(spack mirror list | awk '{print $1}'); do
+          spack mirror rm --scope defaults ${mirror}
+        done
+        spack mirror add spack-build-cache ~/spack-build-cache
+        spack concretize
+        # Run installation and run CTest suite
+        if [  "${{ steps.cache.outputs.cache-hit }}" == true ]; then deps=only; else deps=auto; fi
+        spack install --verbose --fail-fast --no-check-signature --use-buildcache package:never,dependencies:${deps} --test root
+        # Run 'spack load' to check for obvious errors in setup_run_environment
+        spack load nemsio
+        ls $NEMSIO_LIB
+        spack buildcache push --only dependencies --unsigned --allow-root ~/spack-build-cache nemsio
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: spackci-ctest-output-${{ matrix.os }}-${{ matrix.openmp }}
+        path: ${{ github.workspace }}/nemsio/spack-build-*/Testing/Temporary/LastTest.log
+
+  # This job validates the Spack recipe by making sure each cmake build option is represented
+  recipe-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    
+    - name: checkout-nemsio
+      uses: actions/checkout@v4
+      with: 
+        path: nemsio
+
+    - name: recipe-check
+      run: |
+        echo "If this jobs fails, look at the most recently output CMake option below and make sure that option appears in spack/package.py"
+        for opt in $(grep -ioP '^option\(\K(?!(ENABLE_DOCS))[^ ]+' $GITHUB_WORKSPACE/nemsio/CMakeLists.txt) ; do
+          echo "Checking for presence of '$opt' CMake option in package.py"
+          grep -cP "define.+\b${opt}\b" $GITHUB_WORKSPACE/nemsio/spack/package.py
+        done

--- a/spack/README
+++ b/spack/README
@@ -1,0 +1,3 @@
+This directory contains an authoritative, up-to-date Spack recipe for NCEPLIBS-nemsio, which is found under Spack as "nemsio".
+
+Before each release of NCEPLIBS-nemsio, this file should be updated to accommodate changes in build options, etc., and .github/workflows/spack.yml should be updated to exercise all variants. Only the version entry should need to be updated after the release prior to incorporation into the Spack repository and the JCSDA Spack fork.

--- a/spack/package.py
+++ b/spack/package.py
@@ -1,0 +1,50 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Nemsio(CMakePackage):
+    """The NOAA Environmental Modeling System I/O (NEMSIO) library. The
+    basic functions it provides are to read and write data sets for all the
+    NEMS applications.
+
+    This is part of NOAA's NCEPLIBS project."""
+
+    homepage = "https://noaa-emc.github.io/NCEPLIBS-nemsio"
+    url = "https://github.com/NOAA-EMC/NCEPLIBS-nemsio/archive/refs/tags/v2.5.2.tar.gz"
+    git = "https://github.com/NOAA-EMC/NCEPLIBS-nemsio"
+
+    maintainers("edwardhartnett", "AlexanderRichert-NOAA", "Hang-Lei-NOAA")
+
+    variant("mpi", default=True, description="Build Nemsio with MPI")
+    # Nemsio 2.5.3 and below require MPI
+    conflicts("~mpi", when="@:2.5.3")
+
+    version("develop", branch="develop")
+    version("2.5.4", sha256="186a5f37d509d280c0237d4917db86ad676c5dd12d8a892df0333a10e751e481")
+    version("2.5.3", sha256="3fe8a781fc96197803d369cafe0138f3a5cbbca9816a7f8fd57567a1719a4d49")
+    version("2.5.2", sha256="c59e9379969690de8d030cbf4bbbbe3726faf13c304f3b88b0f6aec1496d2c08")
+
+    depends_on("bacio")
+    depends_on("mpi", when="+mpi")
+
+    # nemsio 2.5.2 and earlier depend on w3nco.
+    depends_on("w3nco", when="@:2.5.2")
+
+    # nemsio 2.5.3 and later depend on w3emc-2.9.0 or later.
+    depends_on("w3emc@2.9.0:", when="@2.5.3:")
+
+    def cmake_args(self):
+        args = [self.define_from_variant("ENABLE_MPI", "mpi")]
+
+        if self.spec.satisfies("+mpi"):
+            args.append(self.define("CMAKE_Fortran_COMPILER", self.spec["mpi"].mpifc))
+
+        return args
+
+    def check(self):
+        with working_dir(self.builder.build_directory):
+            make("test")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ if(MPI_Fortran_FOUND)
     nemsio_module_mpi.f90)
 endif()
 
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|IntelLLVM)$")
   set(CMAKE_Fortran_FLAGS
       "-g -traceback -convert big_endian -assume byterecl -fp-model strict ${CMAKE_Fortran_FLAGS}"
   )


### PR DESCRIPTION
This PR adds IntelLLVM (OneAPI) support (including CI tests for both intel compilers) and Spack-based CI tests (which use OpenMPI).

Fixes #68
Fixes #69 
Fixes #70