### PR TITLE
Use EMC CI actions

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -23,8 +23,6 @@ jobs:
 
     - name: checkout
       uses: actions/checkout@v4
-      with:
-        submodules: true
 
       # See https://software.intel.com/content/www/us/en/develop/articles/oneapi-repo-instructions.html
     - name: "Install Intel"

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -24,7 +24,6 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
       with:
-        path: nemsio
         submodules: true
 
 
@@ -51,6 +50,6 @@ jobs:
 
     - name: Build and test
       run: |
-        cmake -B ${{ github.workspace }}/nemsio/build -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc" ..
-        cmake --build ${{ github.workspace }}/nemsio/build --parallel 2 VERBOSE=1
-        cmake --build ${{ github.workspace }}/nemsio/build --target=test --verbose --output-on-failure --rerun-failed
+        cmake -B build -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc"
+        cmake --build build --parallel 2 VERBOSE=1
+        cmake --build build --target=test --verbose --output-on-failure --rerun-failed

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -21,7 +21,12 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v4
+    - name: checkout
+      uses: actions/checkout@v4
+      with:
+        path: nemsio
+        submodules: true
+
 
       # See https://software.intel.com/content/www/us/en/develop/articles/oneapi-repo-instructions.html
     - name: "Install Intel"
@@ -46,6 +51,6 @@ jobs:
 
     - name: Build and test
       run: |
-        cmake -B build -DCMAKE_PREFIX_PATH='~/bacio;~/w3emc' ..
-        cmake --build build --parallel 2 VERBOSE=1
-        cmake --build build --target=test --verbose --output-on-failure --rerun-failed
+        cmake -B nemsio/build -DCMAKE_PREFIX_PATH='~/bacio;~/w3emc' ..
+        cmake --build nemsio/build --parallel 2 VERBOSE=1
+        cmake --build nemsio/build --target=test --verbose --output-on-failure --rerun-failed

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -47,9 +47,10 @@ jobs:
         bacio-version: develop
         w3emc-version: develop
         w3emc-cmake-args: -DBUILD_WITH_BUFR=OFF
+        key-add: -Intel
 
     - name: Build and test
       run: |
         cmake -B build -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc"
         cmake --build build --parallel 2 --verbose
-        cmake --build build --target=test --verbose --output-on-failure --rerun-failed
+        ctest --test-dir build --verbose --output-on-failure --rerun-failed

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -12,12 +12,6 @@ on:
     branches:
     - develop
 
-# Use custom shell with -l so .bash_profile is sourced which loads intel/oneapi/setvars.sh
-# without having to do it in manually every step
-defaults:
-  run:
-    shell: bash -leo pipefail {0}
-
 jobs:
   Intel:
     runs-on: ubuntu-latest
@@ -27,60 +21,31 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
       # See https://software.intel.com/content/www/us/en/develop/articles/oneapi-repo-instructions.html
-    - name: install-intel
+    - name: "Install Intel"
+      uses: NOAA-EMC/ci-install-intel-toolkit@develop
+      with:
+        install-mpi: true
+
+    - name: "Compiler setup"
       run: |
-        cd /tmp
-        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-        rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-        sudo apt-get update
-        sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-openmp intel-oneapi-mpi intel-oneapi-mpi-devel intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-compiler-fortran
-        echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
         if [ ${{ matrix.compilers }} == "oneapi" ]; then
           echo "export CC=mpiicx FC=mpiifx" >> ~/.bash_profile
         elif [ ${{ matrix.compilers }} == "intel" ]; then
           echo "export CC=mpiicc FC=mpiifort" >> ~/.bash_profile
         fi
 
-    - name: checkout-bacio
-      uses: actions/checkout@v2
+    - name: "Build dependencies"
+      uses: NOAA-EMC/ci-build-nceplibs@develop
       with:
-        repository: NOAA-EMC/NCEPLIBS-bacio
-        path: bacio
-        ref: develop
+        bacio-version: develop
+        w3emc-version: develop
+        w3emc-cmake-args: -DBUILD_WITH_BUFR=OFF
 
-    - name: build-bacio
+    - name: Build and test
       run: |
-        cd bacio
-        mkdir build
-        cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~/bacio
-        make -j2
-        make install
-
-    - name: checkout-w3emc
-      uses: actions/checkout@v2
-      with:
-        repository: NOAA-EMC/NCEPLIBS-w3emc
-        path: w3emc
-        ref: develop
-
-    - name: build-w3emc
-      run: |
-        cd w3emc
-        mkdir build
-        cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~/w3emc -DCMAKE_PREFIX_PATH="~/" -DBUILD_WITH_BUFR=OFF
-        make -j2
-        make install
-
-    - name: build and test
-      run: |
-        mkdir build && cd build
-        cmake -DCMAKE_PREFIX_PATH='~/bacio;~/w3emc' ..
-        make -j2 VERBOSE=1
-        ctest --verbose --output-on-failure --rerun-failed
+        cmake -B build -DCMAKE_PREFIX_PATH='~/bacio;~/w3emc' ..
+        cmake --build build --parallel 2 VERBOSE=1
+        cmake --build build --target=test --verbose --output-on-failure --rerun-failed

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -51,6 +51,6 @@ jobs:
 
     - name: Build and test
       run: |
-        cmake -B nemsio/build -DCMAKE_PREFIX_PATH='~/bacio;~/w3emc' ..
-        cmake --build nemsio/build --parallel 2 VERBOSE=1
-        cmake --build nemsio/build --target=test --verbose --output-on-failure --rerun-failed
+        cmake -B ${{ github.workspace }}/nemsio/build -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc" ..
+        cmake --build ${{ github.workspace }}/nemsio/build --parallel 2 VERBOSE=1
+        cmake --build ${{ github.workspace }}/nemsio/build --target=test --verbose --output-on-failure --rerun-failed

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -26,20 +26,12 @@ jobs:
       with:
         submodules: true
 
-
       # See https://software.intel.com/content/www/us/en/develop/articles/oneapi-repo-instructions.html
     - name: "Install Intel"
       uses: NOAA-EMC/ci-install-intel-toolkit@develop
       with:
         install-mpi: true
-
-    - name: "Compiler setup"
-      run: |
-        if [ ${{ matrix.compilers }} == "oneapi" ]; then
-          echo -ne "CC=mpiicx\nFC=mpiifx" >> $GITHUB_ENV
-        elif [ ${{ matrix.compilers }} == "intel" ]; then
-          echo -ne "CC=mpiicc\nFC=mpiifort" >> $GITHUB_ENV
-        fi
+        mpi-wrapper-setup: ${{ matrix.compilers }}
 
     - name: "Build dependencies"
       uses: NOAA-EMC/ci-build-nceplibs@develop
@@ -48,6 +40,7 @@ jobs:
         w3emc-version: develop
         w3emc-cmake-args: -DBUILD_WITH_BUFR=OFF
         key-prefix: Intel-
+        key-suffix: -1
 
     - name: Build and test
       run: |

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -51,5 +51,5 @@ jobs:
     - name: Build and test
       run: |
         cmake -B build -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc"
-        cmake --build build --parallel 2 VERBOSE=1
+        cmake --build build --parallel 2 --verbose
         cmake --build build --target=test --verbose --output-on-failure --rerun-failed

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -36,9 +36,9 @@ jobs:
     - name: "Compiler setup"
       run: |
         if [ ${{ matrix.compilers }} == "oneapi" ]; then
-          echo "export CC=mpiicx FC=mpiifx" >> ~/.bash_profile
+          echo -ne "CC=mpiicx\nFC=mpiifx" >> $GITHUB_ENV
         elif [ ${{ matrix.compilers }} == "intel" ]; then
-          echo "export CC=mpiicc FC=mpiifort" >> ~/.bash_profile
+          echo -ne "CC=mpiicc\nFC=mpiifort" >> $GITHUB_ENV
         fi
 
     - name: "Build dependencies"
@@ -47,7 +47,7 @@ jobs:
         bacio-version: develop
         w3emc-version: develop
         w3emc-cmake-args: -DBUILD_WITH_BUFR=OFF
-        key-add: -Intel
+        key-prefix: Intel-
 
     - name: Build and test
       run: |

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -25,7 +25,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    
+
+    - name: "Install MPI"
+      if: ${{ matrix.variants }} == "+mpi"
+      run: |
+        sudo apt-get install openmpi openmpi-dev
+
     - name: "Build Spack package"
       uses: NOAA-EMC/ci-test-spack-package@develop
       with:
@@ -35,6 +40,7 @@ jobs:
         use-repo-cache: true
         spack-compiler: gcc
         repo-cache-key-suffix: ${{ matrix.os }}-${{ matrix.variants }}-1
+        spack-externals: cmake gmake perl openmpi
 
   # This job validates the Spack recipe by making sure each cmake build option is represented
   recipe-check:

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -29,7 +29,7 @@ jobs:
     - name: "Install MPI"
       if: ${{ matrix.variants == '+mpi' }}
       run: |
-        sudo apt-get install libopenmpi libopenmpi-dev
+        sudo apt-get install openmpi-bin libopenmpi-dev
 
     - name: "Build Spack package"
       uses: NOAA-EMC/ci-test-spack-package@develop

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -33,7 +33,7 @@ jobs:
         package-name: nemsio
         package-variants: ${{ matrix.variants }} ^bufr~python
         custom-recipe: spack/package.py
-        use-build-cache: false
+        use-repo-cache: true
         spack-compiler: gcc
 
     - name: Upload test results

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
 
     - name: "Install MPI"
-      if: ${{ matrix.variants == "+mpi" }}
+      if: ${{ matrix.variants == '+mpi' }}
       run: |
         sudo apt-get install libopenmpi libopenmpi-dev
 

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
 
     - name: "Install MPI"
-      if: ${{ matrix.variants }} == "+mpi"
+      if: ${{ matrix.variants == "+mpi" }}
       run: |
         sudo apt-get install libopenmpi libopenmpi-dev
 

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -40,6 +40,8 @@ jobs:
   recipe-check:
     runs-on: ubuntu-latest
 
+    steps:
+
     - name: recipe-check
       uses: NOAA-EMC/ci-check-spack-recipe@develop
       with:

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -29,7 +29,7 @@ jobs:
     - name: "Install MPI"
       if: ${{ matrix.variants }} == "+mpi"
       run: |
-        sudo apt-get install openmpi openmpi-dev
+        sudo apt-get install libopenmpi libopenmpi-dev
 
     - name: "Build Spack package"
       uses: NOAA-EMC/ci-test-spack-package@develop

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -26,46 +26,15 @@ jobs:
 
     steps:
     
-    - name: checkout-nemsio
-      uses: actions/checkout@v4
-      with: 
-        path: nemsio
 
-    - name: cache-spack
-      id: cache-spack
-      uses: actions/cache@v3
+    - name: "Build Spack package"
+      uses: NOAA-EMC/ci-test-spack-package@develop
       with:
-        path: ~/spack-build-cache
-        key: spack-build-cache-${{ matrix.os }}-${{ matrix.variants }}-1
-
-    - name: spack-build-and-test
-      run: |
-        if [[ "${{ matrix.variants }}" =~ "+mpi" ]]; then
-          sudo apt install openmpi-bin libopenmpi-dev
-        fi
-        cd
-        git clone -c feature.manyFiles=true https://github.com/jcsda/spack
-        . spack/share/spack/setup-env.sh
-        spack env create nemsio-env
-        spack env activate nemsio-env
-        cp $GITHUB_WORKSPACE/nemsio/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/nemsio/package.py
-        spack develop --no-clone --path $GITHUB_WORKSPACE/nemsio nemsio@develop
-        spack config add "packages:all:providers:mpi:[openmpi]"
-        spack add nemsio@develop%gcc@11 ${{ matrix.variants }} ^bufr~python
-        spack external find cmake gmake openmpi
-        spack config add "packages:openmpi:buildable:false"
-        for mirror in $(spack mirror list | awk '{print $1}'); do
-          spack mirror rm --scope defaults ${mirror}
-        done
-        spack mirror add spack-build-cache ~/spack-build-cache
-        spack concretize
-        # Run installation and run CTest suite
-        if [  "${{ steps.cache.outputs.cache-hit }}" == true ]; then deps=only; else deps=auto; fi
-        spack install --verbose --fail-fast --no-check-signature --use-buildcache package:never,dependencies:${deps} --test root
-        # Run 'spack load' to check for obvious errors in setup_run_environment
-        spack load nemsio
-        ls $NEMSIO_LIB
-        spack buildcache push --only dependencies --unsigned --allow-root ~/spack-build-cache nemsio
+        package-name: nemsio
+        package-variants: ${{ matrix.variants }} ^bufr~python
+        custom-recipe: spack/package.py
+        use-build-cache: false
+        spack-compiler: gcc
 
     - name: Upload test results
       uses: actions/upload-artifact@v3

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -26,7 +26,6 @@ jobs:
 
     steps:
     
-
     - name: "Build Spack package"
       uses: NOAA-EMC/ci-test-spack-package@develop
       with:
@@ -35,29 +34,15 @@ jobs:
         custom-recipe: spack/package.py
         use-repo-cache: true
         spack-compiler: gcc
-
-    - name: Upload test results
-      uses: actions/upload-artifact@v3
-      if: ${{ failure() }}
-      with:
-        name: spackci-ctest-output-${{ matrix.os }}-${{ matrix.openmp }}
-        path: ${{ github.workspace }}/nemsio/spack-build-*/Testing/Temporary/LastTest.log
+        repo-cache-key-suffix: ${{ matrix.os }}-${{ matrix.variants }}-1
 
   # This job validates the Spack recipe by making sure each cmake build option is represented
   recipe-check:
     runs-on: ubuntu-latest
 
-    steps:
-    
-    - name: checkout-nemsio
-      uses: actions/checkout@v4
-      with: 
-        path: nemsio
-
     - name: recipe-check
-      run: |
-        echo "If this jobs fails, look at the most recently output CMake option below and make sure that option appears in spack/package.py"
-        for opt in $(grep -ioP '^option\(\K(?!(ENABLE_DOCS))[^ ]+' $GITHUB_WORKSPACE/nemsio/CMakeLists.txt) ; do
-          echo "Checking for presence of '$opt' CMake option in package.py"
-          grep -cP "define.+\b${opt}\b" $GITHUB_WORKSPACE/nemsio/spack/package.py
-        done
+      uses: NOAA-EMC/ci-check-spack-recipe@develop
+      with:
+        recipe-file: package/spack/package.py
+        cmakelists-txt: package/CMakeLists.txt
+        ignore-list: ENABLE_DOCS

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         cd nemsio
         mkdir build
         cd build
-        cmake .. -DENABLE_DOCS=ON -DENABLE_TESTS=ON -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0"
+        cmake .. -DENABLE_DOCS=ON -DENABLE_TESTS=ON -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0"
         make -j2
 
     - name: test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,32 +21,27 @@ jobs:
         w3emc-version: develop
         w3emc-cmake-args: -DBUILD_WITH_BUFR=OFF
 
-    - name: checkout
-      uses: actions/checkout@v2
+    - name: "Build nemsio"
+      uses: NOAA-EMC/ci-build-cmake-code@develop
       with:
-        path: nemsio
-        submodules: true
-
-    - name: build
-      run: |
-        cd nemsio
-        mkdir build
-        cd build
-        cmake .. -DENABLE_DOCS=ON -DENABLE_TESTS=ON -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc" -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0"
-        make -j2
+        package-name: NCEPLIBS-nemsio
+        package-org: NOAA-EMC
+        git-ref: ${{ github.sha }}
+        cmake-args: cmake .. -DENABLE_DOCS=ON -DENABLE_TESTS=ON -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc" -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0"
+        repo-cache: false
 
     - name: test
       run: |
-        cd $GITHUB_WORKSPACE/nemsio/build
+        cd $GITHUB_WORKSPACE/nceplibs/NCEPLIBS-nemsio/build
         ctest --output-on-failure
 
     - name: run-gcovr
       run: |
-        cd $GITHUB_WORKSPACE/nemsio/build
+        cd $GITHUB_WORKSPACE/nceplibs/NCEPLIBS-nemsio/build
         gcovr -r .. -v  --html-details -o test-coverage.html
 
     - name: upload-test-coverage
       uses: actions/upload-artifact@v2
       with:
         name: nemsio-test-coverage
-        path: nemsio/build/*.html
+        path: nceplibs/NCEPLIBS-nemsio/build/*.html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,16 +32,16 @@ jobs:
 
     - name: test
       run: |
-        cd $GITHUB_WORKSPACE/nceplibs/NCEPLIBS-nemsio/build
+        cd $GITHUB_WORKSPACE/nceplibs/src/NCEPLIBS-nemsio/build
         ctest --output-on-failure
 
     - name: run-gcovr
       run: |
-        cd $GITHUB_WORKSPACE/nceplibs/NCEPLIBS-nemsio/build
+        cd $GITHUB_WORKSPACE/nceplibs/src/NCEPLIBS-nemsio/build
         gcovr -r .. -v  --html-details -o test-coverage.html
 
     - name: upload-test-coverage
       uses: actions/upload-artifact@v2
       with:
         name: nemsio-test-coverage
-        path: nceplibs/NCEPLIBS-nemsio/build/*.html
+        path: nceplibs/src/NCEPLIBS-nemsio/build/*.html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         package-name: NCEPLIBS-nemsio
         package-org: NOAA-EMC
         git-ref: ${{ github.sha }}
-        cmake-args: cmake .. -DENABLE_DOCS=ON -DENABLE_TESTS=ON -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc" -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0"
+        cmake-args: -DENABLE_DOCS=ON -DENABLE_TESTS=ON -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc" -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0"
         repo-cache: false
 
     - name: test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
 
-    - name: install-mpi
+    - name: "Install MPI"
       run: |
         sudo apt-get install libmpich-dev doxygen gcovr
 
@@ -30,18 +30,18 @@ jobs:
         cmake-args: -DENABLE_DOCS=ON -DENABLE_TESTS=ON -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc" -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0"
         repo-cache: false
 
-    - name: test
+    - name: "Run CTest suite"
       run: |
         cd $GITHUB_WORKSPACE/nceplibs/src/NCEPLIBS-nemsio/build
         ctest --output-on-failure
 
-    - name: run-gcovr
+    - name: "Build gcovr test coverage report"
       run: |
         cd $GITHUB_WORKSPACE/nceplibs/src/NCEPLIBS-nemsio/build
         gcovr -r .. -v  --html-details -o test-coverage.html
 
-    - name: upload-test-coverage
-      uses: actions/upload-artifact@v2
+    - name: "Upload test coverage report"
+      uses: actions/upload-artifact@v4
       with:
         name: nemsio-test-coverage
         path: nceplibs/src/NCEPLIBS-nemsio/build/*.html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,37 +14,12 @@ jobs:
       run: |
         sudo apt-get install libmpich-dev doxygen gcovr
 
-    - name: checkout-bacio
-      uses: actions/checkout@v2
+    - name: "Build dependencies"
+      uses: NOAA-EMC/ci-build-nceplibs@develop
       with:
-        repository: NOAA-EMC/NCEPLIBS-bacio
-        path: bacio
-        ref: develop
-
-    - name: build-bacio
-      run: |
-        cd bacio
-        mkdir build
-        cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~/bacio
-        make -j2
-        make install
-
-    - name: checkout-w3emc
-      uses: actions/checkout@v2
-      with:
-        repository: NOAA-EMC/NCEPLIBS-w3emc
-        path: w3emc
-        ref: develop
-
-    - name: build-w3emc
-      run: |
-        cd w3emc
-        mkdir build
-        cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~/w3emc -DCMAKE_PREFIX_PATH="~/" -DBUILD_WITH_BUFR=OFF
-        make -j2
-        make install
+        bacio-version: develop
+        w3emc-version: develop
+        w3emc-cmake-args: -DBUILD_WITH_BUFR=OFF
 
     - name: checkout
       uses: actions/checkout@v2
@@ -57,13 +32,14 @@ jobs:
         cd nemsio
         mkdir build
         cd build
-        cmake .. -DENABLE_DOCS=ON -DENABLE_TESTS=ON -DCMAKE_PREFIX_PATH="~/" -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0"
+        cmake .. -DENABLE_DOCS=ON -DENABLE_TESTS=ON -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0"
         make -j2
 
     - name: test
       run: |
         cd $GITHUB_WORKSPACE/nemsio/build
         ctest --output-on-failure
+
     - name: run-gcovr
       run: |
         cd $GITHUB_WORKSPACE/nemsio/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         cd nemsio
         mkdir build
         cd build
-        cmake .. -DENABLE_DOCS=ON -DENABLE_TESTS=ON -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0"
+        cmake .. -DENABLE_DOCS=ON -DENABLE_TESTS=ON -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-bacio;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-w3emc" -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0"
         make -j2
 
     - name: test


### PR DESCRIPTION
This PR adds the following actions to the CI:
 - [NOAA-EMC/ci-build-nceplibs](https://github.com/NOAA-EMC/ci-build-nceplibs) to build/cache the dependencies
 - [NOAA-EMC/ci-build-cmake-code](https://github.com/NOAA-EMC/ci-build-cmake-code) to build the package itself in main.yml
 - [NOAA-EMC/ci-test-spack-package](https://github.com/NOAA-EMC/ci-test-spack-package) for the Spack-based build-and-test
 - [NOAA-EMC/ci-check-spack-recipe](https://github.com/NOAA-EMC/ci-check-spack-recipe) for doing the Spack recipe check
 - [NOAA-EMC/ci-install-intel-toolkit](https://github.com/NOAA-EMC/ci-install-intel-toolkit) for installing and setting up the Intel compilers/libraries

A few things to note:
 - Caching is all done at the repo level. I intend to circle back later to the possibility of sharing cached packages across repositories.
 - All of the EMC actions use the 'develop' branch. This means that the library's CI will automatically use the most recent versions of these actions. This means we don't have to modify a bunch of different repos to fix one underlying issue with Intel installation, Spack, whatever.
 - I have verified that various failure conditions will cause workflow failures in the various Actions used, but please feel free to poke and prod and make sure that failures cause the desired behavior.
 
If/when this looks good to everyone, I'll start making similar changes for other NCEPLIBS.